### PR TITLE
Add unzip package to php images

### DIFF
--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -25,7 +25,8 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
-        ssmtp
+        ssmtp \
+        unzip
 
 # Installs the PHP extensions
 RUN \

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -25,7 +25,8 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
-        ssmtp
+        ssmtp \
+        unzip
 
 # Installs the PHP extensions
 RUN \

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -25,7 +25,8 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
-        ssmtp
+        ssmtp \
+        unzip
 
 # Installs the PHP extensions
 RUN \

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -25,7 +25,8 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
-        ssmtp
+        ssmtp \
+        unzip
 
 # Installs the PHP extensions
 RUN \


### PR DESCRIPTION
When testing one php image, I realized that I had the following warning 
```
As there is no 'unzip' or '7z' command installed, the zip files are decompressed using the PHP zip extension.
This can cause invalid reports of corrupted archives. In addition, all UNIX permissions (e.g. executable) set in the archive will be lost.
Installing 'unzip' or '7z' (21.01+) can remedy this.
```