### PR TITLE
Remove old elasticsearch images & give flexibility with dedicated version images

### DIFF
--- a/magento2/elasticsearch/.github/workflows/publish.yml
+++ b/magento2/elasticsearch/.github/workflows/publish.yml
@@ -9,40 +9,21 @@ on:
     inputs:
 
 jobs:
-  publish_6x:
-    name: "6.x"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Prepare the build context"
-        uses: actions/checkout@v2
-
-      - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v1
-
-      - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v1
-
-      - name: "Log in to DockerHub"
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: "Build & Publish the Docker image"
-        uses: docker/build-push-action@v2
-        with:
-          context: ./6.x/
-          tags: ajardin/magento2-elasticsearch:6
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref == 'refs/heads/main' }}
-          cache-from: type=registry,ref=ajardin/magento2-elasticsearch:6
-          cache-to: type=inline
-
   publish_7x:
     name: "7.x"
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        elasticsearch-version:
+          - "7.7"
+          - "7.6"
+          - "7.9"
+          - "7.16"
+          - "7.17"
+
     steps:
       - name: "Prepare the build context"
         uses: actions/checkout@v2
@@ -62,9 +43,9 @@ jobs:
       - name: "Build & Publish the Docker image"
         uses: docker/build-push-action@v2
         with:
-          context: ./7.x/
-          tags: ajardin/magento2-elasticsearch:7
+          context: ./${{ matrix.elasticsearch-version }}/
+          tags: ajardin/magento2-elasticsearch:${{ matrix.elasticsearch-version }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/main' }}
-          cache-from: type=registry,ref=ajardin/magento2-elasticsearch:7
+          cache-from: type=registry,ref=ajardin/magento2-elasticsearch:${{ matrix.elasticsearch-version }}
           cache-to: type=inline

--- a/magento2/elasticsearch/7.16/Dockerfile
+++ b/magento2/elasticsearch/7.16/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.0
+
+LABEL org.opencontainers.image.authors="Alexandre Jardin <info@ajardin.fr>"
+LABEL org.opencontainers.image.title="Elasticsearch 7.16 image for a Magento 2 application."
+LABEL org.opencontainers.image.description="https://magento.com/"
+LABEL org.opencontainers.image.source="https://github.com/origamiphp/docker-images/tree/main/magento2/elasticsearch"
+
+# Install ElasticSuite requirements (https://github.com/Smile-SA/elasticsuite/wiki/ModuleInstall)
+RUN \
+    elasticsearch-plugin install analysis-icu && \
+    elasticsearch-plugin install analysis-phonetic

--- a/magento2/elasticsearch/7.17/Dockerfile
+++ b/magento2/elasticsearch/7.17/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+
+LABEL org.opencontainers.image.authors="Alexandre Jardin <info@ajardin.fr>"
+LABEL org.opencontainers.image.title="Elasticsearch 7.17 image for a Magento 2 application."
+LABEL org.opencontainers.image.description="https://magento.com/"
+LABEL org.opencontainers.image.source="https://github.com/origamiphp/docker-images/tree/main/magento2/elasticsearch"
+
+# Install ElasticSuite requirements (https://github.com/Smile-SA/elasticsuite/wiki/ModuleInstall)
+RUN \
+    elasticsearch-plugin install analysis-icu && \
+    elasticsearch-plugin install analysis-phonetic

--- a/magento2/elasticsearch/7.6/Dockerfile
+++ b/magento2/elasticsearch/7.6/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.0
 
 LABEL org.opencontainers.image.authors="Alexandre Jardin <info@ajardin.fr>"
-LABEL org.opencontainers.image.title="Elasticsearch 7.x image for a Magento 2 application."
+LABEL org.opencontainers.image.title="Elasticsearch 7.6 image for a Magento 2 application."
 LABEL org.opencontainers.image.description="https://magento.com/"
 LABEL org.opencontainers.image.source="https://github.com/origamiphp/docker-images/tree/main/magento2/elasticsearch"
 

--- a/magento2/elasticsearch/7.7/Dockerfile
+++ b/magento2/elasticsearch/7.7/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+
+LABEL org.opencontainers.image.authors="Alexandre Jardin <info@ajardin.fr>"
+LABEL org.opencontainers.image.title="Elasticsearch 7.7 image for a Magento 2 application."
+LABEL org.opencontainers.image.description="https://magento.com/"
+LABEL org.opencontainers.image.source="https://github.com/origamiphp/docker-images/tree/main/magento2/elasticsearch"
+
+# Install ElasticSuite requirements (https://github.com/Smile-SA/elasticsuite/wiki/ModuleInstall)
+RUN \
+    elasticsearch-plugin install analysis-icu && \
+    elasticsearch-plugin install analysis-phonetic

--- a/magento2/elasticsearch/7.9/Dockerfile
+++ b/magento2/elasticsearch/7.9/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.15
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.0
 
 LABEL org.opencontainers.image.authors="Alexandre Jardin <info@ajardin.fr>"
-LABEL org.opencontainers.image.title="Elasticsearch 6.x image for a Magento 2 application."
+LABEL org.opencontainers.image.title="Elasticsearch 7.9 image for a Magento 2 application."
 LABEL org.opencontainers.image.description="https://magento.com/"
 LABEL org.opencontainers.image.source="https://github.com/origamiphp/docker-images/tree/main/magento2/elasticsearch"
 

--- a/magento2/elasticsearch/README.md
+++ b/magento2/elasticsearch/README.md
@@ -5,15 +5,18 @@
 * [Elasticsuite requirements][1] (`analysis-icu` and `analysis-phonetic` plugins)
 
 ## 🐳 Supported tags
-* [![Image size (7)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7)](/magento2/elasticsearch/7.x/Dockerfile)
-* [![Image size (6)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/6?label=ajardin%2Fmagento2-elasticsearch%3A6)](/magento2/elasticsearch/6.x/Dockerfile)
+* [![Image size (7.17)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7.17)](/magento2/elasticsearch/7.17/Dockerfile)
+* [![Image size (7.16)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7.16)](/magento2/elasticsearch/7.16/Dockerfile)
+* [![Image size (7.9)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7.9)](/magento2/elasticsearch/7.9/Dockerfile)
+* [![Image size (7.7)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7.7)](/magento2/elasticsearch/7.7/Dockerfile)
+* [![Image size (7.6)](https://img.shields.io/docker/image-size/ajardin/magento2-elasticsearch/7?label=ajardin%2Fmagento2-elasticsearch%3A7.6)](/magento2/elasticsearch/7.6/Dockerfile)
 
 ## 🚀 Usage
 ```yaml
 services:
 # [...]
   elasticsearch:
-    image: ajardin/magento2-elasticsearch:7
+    image: ajardin/magento2-elasticsearch:7.17
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false


### PR DESCRIPTION
I'm not sure about this one tbh but since Magento doesn't support only 1 version accross, I think it would be better to at least have a the latest supported versions.

System prerequisites: https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html
Magento support lifecycle: https://experienceleague.adobe.com/docs/commerce-operations/release/lifecycle-policy.html