### PR TITLE
Fix the version of Simplify monorepo-split

### DIFF
--- a/.github/workflows/images-split.yml
+++ b/.github/workflows/images-split.yml
@@ -41,7 +41,7 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        uses: "symplify/monorepo-split-github-action@main"
+        uses: "symplify/monorepo-split-github-action@2.2"
         with:
           package_directory: "${{ matrix.image.local_path }}"
           repository_organization: "origamiphp"


### PR DESCRIPTION
The process is currently [broken](https://github.com/origamiphp/docker-images/actions/runs/3264122340/jobs/5364263809#step:4:59). It may be related to one of the latest commits.