### PR TITLE
Add ssh to the php images

### DIFF
--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
+        ssh-client \
         ssmtp \
         unzip
 

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
+        ssh-client \
         ssmtp \
         unzip
 

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
+        ssh-client \
         ssmtp \
         unzip
 

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         libxml2-utils \
         libxslt-dev \
         libzip-dev \
+        ssh-client \
         ssmtp \
         unzip
 


### PR DESCRIPTION
To fix the error `error: cannot run ssh: No such file or directory` occurring when trying to require a private repository via composer