### PR TITLE
Update permissions for www-data's home folder

### DIFF
--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -72,6 +72,9 @@ RUN \
     usermod -u 1000 www-data && \
     groupmod -g 1000 www-data
 
+# Give www-data permissions to its home folder
+RUN chown www-data:www-data /var/www
+
 # Installs the "netz98/n98-magerun2" package
 RUN \
     curl -sS https://files.magerun.net/n98-magerun2.phar --output /usr/local/bin/magerun2 && \

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -53,6 +53,9 @@ RUN \
     perl -pi -e "s|;pm.status_path = /status|pm.status_path = /php_fpm_status|g" /usr/local/etc/php-fpm.d/www.conf && \
     perl -pi -e "s/mailhub=mail/mailhub=maildev/" /etc/ssmtp/ssmtp.conf
 
+# Give www-data permissions to its home folder
+RUN chown www-data:www-data /var/www
+
 # Installs the JavaScript dependencies
 RUN \
     curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -68,6 +68,9 @@ RUN \
     usermod -u 1000 www-data && \
     groupmod -g 1000 www-data
 
+# Give www-data permissions to its home folder
+RUN chown www-data:www-data /var/www
+
 # Installs the "netz98/n98-magerun2" package
 RUN \
     curl -sS https://files.magerun.net/n98-magerun2.phar --output /usr/local/bin/magerun2 && \

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -68,6 +68,9 @@ RUN \
     usermod -u 1000 www-data && \
     groupmod -g 1000 www-data
 
+# Give www-data permissions to its home folder
+RUN chown www-data:www-data /var/www
+
 # Installs the "netz98/n98-magerun2" package
 RUN \
     curl -sS https://files.magerun.net/n98-magerun2.phar --output /usr/local/bin/magerun2 && \

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -68,6 +68,9 @@ RUN \
     usermod -u 1000 www-data && \
     groupmod -g 1000 www-data
 
+# Give www-data permissions to its home folder
+RUN chown www-data:www-data /var/www
+
 # Installs the "netz98/n98-magerun2" package
 RUN \
     curl -sS https://files.magerun.net/n98-magerun2.phar --output /usr/local/bin/magerun2 && \


### PR DESCRIPTION
Because by default its root:root, and therefore the are issues with ~/.ssh folder auto-creation.